### PR TITLE
Test CI AWS Profile Fix

### DIFF
--- a/TEST-CI-AWS-FIX.md
+++ b/TEST-CI-AWS-FIX.md
@@ -1,0 +1,16 @@
+# Test CI AWS Profile Fix
+
+This PR tests the fix for the AWS profile issue in CI workflows.
+
+## Changes
+- Provider configuration now uses variables instead of hardcoded profile
+- CI workflows pass empty aws_profile for CI environments
+- Should resolve the 'failed to get shared config profile, quanttrader-dev' error
+
+## Expected Results
+- Terraform fmt check should pass
+- Terraform validate should pass  
+- Terraform plan should run without AWS profile errors
+- Security scans should execute successfully
+- Plan output should be posted as PR comment
+


### PR DESCRIPTION
## Summary

This PR tests the fix for the AWS profile issue in CI workflows.

## Changes
- Provider configuration now uses variables instead of hardcoded profile
- CI workflows pass empty aws_profile for CI environments  
- Should resolve the 'failed to get shared config profile, quanttrader-dev' error

## Expected Results
- ✅ Terraform fmt check should pass
- ✅ Terraform validate should pass
- ✅ Terraform plan should run without AWS profile errors
- ✅ Security scans should execute successfully
- ✅ Plan output should be posted as PR comment

## Testing
This PR will verify that the CI workflows now work correctly without requiring the quanttrader-dev AWS profile in the GitHub Actions environment.